### PR TITLE
[feat/#71]-유저ID에 따른 멘토 정보 불러오기 api 추가

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -4,9 +4,9 @@ spring:
 
     datasource:
         driver-class-name: com.mysql.cj.jdbc.Driver
-        url: jdbc:mysql://localhost:3306/testdb?serverTimezone=Asia/Seoul&characterEncoding=UTF-8&useSSL=false
-        username: JHEEE116
-        password: yt1357#1
+        url: jdbc:mysql://${DATABASE_HOST:localhost}:${DATABASE_PORT:3306}/${DATABASE_NAME:test}
+        username: ${DATABASE_USER:root}
+        password: ${DATABASE_PASS:password}
     data:
         redis:
             host: ${REDIS_HOST:localhost}


### PR DESCRIPTION
#71  멘토에 저장된 유저ID에 따른 정보를 불러오는 api 추가 

/api/mentor/detail/1 -> 1번 째 멘토에 대한 정보를 가지고 온다. 