### PR TITLE
[fix/chat-duration] 챗봇 유저 듀레이션 기간 단축 

### DIFF
--- a/src/main/java/startpointwas/domain/chat/repository/ChatRedisRepository.java
+++ b/src/main/java/startpointwas/domain/chat/repository/ChatRedisRepository.java
@@ -37,7 +37,7 @@ public class ChatRedisRepository {
             String json = om.writeValueAsString(payload);
             redis.opsForList().rightPush(keyList(contextId), json);
             redis.opsForSet().add(keyUserCtx(userId), contextId);
-            redis.expire(keyList(contextId), Duration.ofDays(2));
+            redis.expire(keyList(contextId), Duration.ofHours(3));
         } catch (Exception e) {
             e.printStackTrace();
         }


### PR DESCRIPTION
챗봇 대화내역 정보 관련 redis에 정보가 저장되는 기간을 3시간으로 단축 하였습니다.